### PR TITLE
[GOVCMSD10-930] Fix Error in UID1ReportAccessTest.php

### DIFF
--- a/phpunit/tests/GovCMS/Functional/Baseline/UID1ReportAccessTest.php
+++ b/phpunit/tests/GovCMS/Functional/Baseline/UID1ReportAccessTest.php
@@ -3,6 +3,7 @@
 namespace GovCMS\Tests\Functional\Baseline;
 
 use Drupal\Tests\BrowserTestBase;
+use Drupal\user\Entity\User;
 
 /**
  * Tests UID 1 access to the GovCMS system and Drupal status reports.
@@ -30,8 +31,8 @@ class UID1ReportAccessTest extends BrowserTestBase {
 
         // Load the real user object from UserSession object.
         $admin_account = User::load($this->rootUser->id());
-        // The password is empty.
-        $this->assertFalse($admin_account->passRaw);
+        // Check if the password is null.
+        $this->assertNull($admin_account->passRaw);
         // Set the password and save the User.
         $new_password = $this->randomString();
         $admin_account->setPassword($new_password);


### PR DESCRIPTION
We have identified an error "Error: Class "GovCMS\Tests\Functional \Baseline\User" not found" in the UID1ReportAccessTest.php file, which is causing the PHPUnit tests to fail.

