### PR TITLE
[GOVCMSD10-988] Validating default configurations for simplesamlphp_auth module

### DIFF
--- a/phpunit/integration/GovCMS/Modules/simplesamlphp_auth/Config/SimplesamlphpAuthTest.php
+++ b/phpunit/integration/GovCMS/Modules/simplesamlphp_auth/Config/SimplesamlphpAuthTest.php
@@ -1,0 +1,130 @@
+<?php
+namespace GovCMS\Tests\Integration\GovCMS\Modules\simplesamlphp_auth\Config;
+
+use GovCMS\Tests\Integration\GovCMS\Baseline\Functional\GovCMSTestBase;
+
+/**
+ * Test the simplesamlphp_auth module's specific configurations.
+ *
+ * @group simplesamlphp_auth
+ * @group govcms
+ */
+class SimplesamlphpAuthTest extends GovCMSTestBase {
+
+    /**
+     * {@inheritdoc}
+     *
+     * This method is called before each test method to set up the necessary environment.
+     * It ensures a clean state by logging out any currently logged-in user, then creates
+     * a new user with the necessary permissions and logs them in.
+     */
+    protected function setUp(): void {
+        parent::setUp();
+
+        // Log out any currently logged-in user to ensure a clean state.
+        $this->drupalLogout();
+
+        // Create a user with specific permissions and log them in.
+        $user = $this->drupalCreateUser([
+            'administer simplesamlphp_auth',
+        ]);
+        $this->drupalLogin($user);
+    }
+
+    /**
+     * Test disallowing SAML users to set Drupal passwords.
+     *
+     * This test verifies that the configuration setting for disallowing SAML users
+     * from setting Drupal passwords is correctly set to false and that the user
+     * interface does not provide an option for these users to set passwords.
+     */
+    public function testDisallowDrupalPasswordSetting() {
+        // Retrieve the current configuration for the simplesamlphp_auth module.
+        $config = \Drupal::config('simplesamlphp_auth.settings');
+        $set_drupal_pwd = $config->get('set_drupal_pwd');
+
+        // Assert that the setting is false, meaning SAML users cannot set Drupal passwords.
+        $this->assertFalse($set_drupal_pwd, 'SAML users should not be allowed to set Drupal passwords.');
+
+        // Check the user login form to ensure the option to set a Drupal password is not available.
+        $this->drupalGet('user/login');
+        $this->assertSession()->elementNotExists('css', 'input#edit-allow-drupal-password-setting');
+    }
+
+    /**
+     * Test hiding the Federated Login link on the user login form.
+     *
+     * This test checks that the configuration setting for showing the Federated Login link
+     * is set to false, and confirms that the link is not displayed on the user login page.
+     */
+    public function testHideFederatedLoginLink() {
+        // Retrieve the current configuration for the simplesamlphp_auth module.
+        $config = \Drupal::config('simplesamlphp_auth.settings');
+        $login_link_show = $config->get('login_link_show');
+
+        // Assert that the setting is false, meaning the Federated Login link should be hidden.
+        $this->assertFalse($login_link_show, 'The Federated Login link should be hidden.');
+
+        // Check the user login form to ensure the Federated Login link is not displayed.
+        $this->drupalGet('user/login');
+        $this->assertSession()->elementNotExists('css', 'a#federated-login-link');
+    }
+
+    /**
+     * Test that auto-provisioning (automatic registration) of users is disabled.
+     *
+     * This test ensures that the auto-provisioning feature, which automatically registers
+     * SSO users in Drupal, is disabled.
+     */
+    public function testAutoProvisioningDisabled() {
+        // Retrieve the current configuration for the simplesamlphp_auth module.
+        $config = \Drupal::config('simplesamlphp_auth.settings');
+        $register_users = $config->get('register_users');
+
+        // Assert that the setting is false, meaning auto-provisioning of users is disabled.
+        $this->assertFalse($register_users, 'Auto-provisioning of users should be disabled.');
+
+        // Check that a non-existing SSO user is not automatically registered.
+        $username = 'non_existing_user';
+        $user_exists = user_load_by_name($username);
+        $this->assertFalse($user_exists, 'SSO users should not be automatically registered.');
+    }
+
+    /**
+     * Test that cookies are only transmitted over HTTPS.
+     *
+     * This test verifies that the module's configuration ensures cookies are transmitted
+     * only over secure HTTPS connections.
+     */
+    public function testCookiesOnlyOverHttps() {
+        // Retrieve the current configuration for the simplesamlphp_auth module.
+        $config = \Drupal::config('simplesamlphp_auth.settings');
+        $secure = $config->get('secure');
+
+        // Assert that the setting is true, meaning cookies are only transmitted over HTTPS.
+        $this->assertTrue($secure, 'Cookies should only be transmitted over HTTPS.');
+    }
+
+    /**
+     * Test that cookies are set with the HttpOnly attribute.
+     *
+     * This test checks that cookies are configured with the HttpOnly attribute,
+     * which prevents them from being accessed via JavaScript, enhancing security.
+     */
+    public function testCookiesHttpOnly() {
+        // Retrieve the current configuration for the simplesamlphp_auth module.
+        $config = \Drupal::config('simplesamlphp_auth.settings');
+        $httponly = $config->get('httponly');
+
+        // Assert that the setting is true, meaning cookies have the HttpOnly attribute set.
+        $this->assertTrue($httponly, 'Cookies should be set with the HttpOnly attribute.');
+
+        // Verify that the HttpOnly attribute is present in the Set-Cookie headers.
+        $this->drupalGet('user/login');
+        $cookies = $this->getSession()->getResponseHeaders()['set-cookie'];
+        foreach ($cookies as $cookie) {
+            $this->assertStringContainsString('HttpOnly', $cookie, 'Cookie should have the HttpOnly attribute set.');
+        }
+    }
+
+}

--- a/phpunit/integration/GovCMS/Modules/simplesamlphp_auth/Functional/SimplesamlphpAuthTest.php
+++ b/phpunit/integration/GovCMS/Modules/simplesamlphp_auth/Functional/SimplesamlphpAuthTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace GovCMS\Tests\Integration\GovCMS\Modules\simplesamlphp_auth\Config;
+namespace GovCMS\Tests\Integration\GovCMS\Modules\simplesamlphp_auth\Functional;
 
 use GovCMS\Tests\Integration\GovCMS\Baseline\Functional\GovCMSTestBase;
 
@@ -18,11 +18,18 @@ class SimplesamlphpAuthTest extends GovCMSTestBase {
      * It ensures a clean state by logging out any currently logged-in user, then creates
      * a new user with the necessary permissions and logs them in.
      */
+    #[\Override]
     protected function setUp(): void {
+        // Check if the simplesamlphp_auth module exists in the codebase.
+        if (!\Drupal::moduleHandler()->moduleExists('simplesamlphp_auth')) {
+            $this->markTestSkipped('The simplesamlphp_auth module is not available.');
+        }
         parent::setUp();
 
         // Log out any currently logged-in user to ensure a clean state.
-        $this->drupalLogout();
+        if (\Drupal::currentUser()->isAuthenticated()) {
+            $this->drupalLogout();
+        }
 
         // Create a user with specific permissions and log them in.
         $user = $this->drupalCreateUser([

--- a/phpunit/integration/GovCMS/Modules/simplesamlphp_auth/Functional/SimplesamlphpAuthTest.php
+++ b/phpunit/integration/GovCMS/Modules/simplesamlphp_auth/Functional/SimplesamlphpAuthTest.php
@@ -12,18 +12,24 @@ use GovCMS\Tests\Integration\GovCMS\Baseline\Functional\GovCMSTestBase;
 class SimplesamlphpAuthTest extends GovCMSTestBase {
 
     /**
+     * Modules to enable during the test.
+     *
+     * This property specifies the modules that should be enabled for this test class.
+     * The testing framework ensures these modules are available and enabled before the tests are run.
+     * If the module is not available, the test will be skipped.
+     *
+     * @var array
+     */
+    public static $modules = ['simplesamlphp_auth'];
+
+    /**
      * {@inheritdoc}
      *
      * This method is called before each test method to set up the necessary environment.
      * It ensures a clean state by logging out any currently logged-in user, then creates
      * a new user with the necessary permissions and logs them in.
      */
-    #[\Override]
     protected function setUp(): void {
-        // Check if the simplesamlphp_auth module exists in the codebase.
-        if (!\Drupal::moduleHandler()->moduleExists('simplesamlphp_auth')) {
-            $this->markTestSkipped('The simplesamlphp_auth module is not available.');
-        }
         parent::setUp();
 
         // Log out any currently logged-in user to ensure a clean state.
@@ -33,7 +39,7 @@ class SimplesamlphpAuthTest extends GovCMSTestBase {
 
         // Create a user with specific permissions and log them in.
         $user = $this->drupalCreateUser([
-            'administer simplesamlphp_auth',
+            'administer simplesamlphp authentication',
         ]);
         $this->drupalLogin($user);
     }


### PR DESCRIPTION
Create php unit test for testing default config to check for conflicts with other security policies such as password policy.
