### PR TITLE
refactor github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,9 @@
+---
 name: Docker Image CI
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,10 +1,11 @@
+---
 name: GovCMS CI Tests - Cypress
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
   pull_request:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
 
 permissions:
   contents: read
@@ -24,11 +25,19 @@ jobs:
     steps:
       - name: Install GovCMS site
         run: |
-          docker exec ${{ job.services.web.id }} drush site-install -y govcms --db-url=sqlite://sites/default/files/.ht.sqlite --site-name='GovCMS' --account-pass=password install_configure_form.enable_update_status_emails=NULL install_configure_form.enable_update_status_module=NULL || true
+          docker exec ${{ job.services.web.id }} drush site-install -y govcms \
+            --db-url=sqlite://sites/default/files/.ht.sqlite \
+            --site-name='GovCMS' \
+            --account-pass=password \
+            install_configure_form.enable_update_status_emails=NULL \
+            install_configure_form.enable_update_status_module=NULL || true
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           cd cy && npm ci
       - name: Run Cypress tests
+        # yamllint disable rule:line-length
         run: |
-          cd cy && npx cypress run --config baseUrl=http://localhost --env drupalDrushCmdLine="docker exec ${{ job.services.web.id }} drush --root=/app/web %command" --spec "cypress/e2e/**/*.cy.js,!cypress/e2e/3-modules/module_versions.cy.js"
+          cd cy && npx cypress run \
+            --config baseUrl=http://localhost \
+            --env drupalDrushCmdLine="docker exec ${{ job.services.web.id }} drush --root=/app/web %command" --spec "cypress/e2e/**/*.cy.js,!cypress/e2e/3-modules/module_versions.cy.js"

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,0 +1,39 @@
+---
+name: Generate test documentation
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches: ["3.x-develop"]
+  pull_request:
+    branches: ["3.x-develop"]
+
+jobs:
+  generate-docs:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{secrets.BYPASS_BRANCH_PROTECTION}}
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+
+      - name: Run PHP script to generate Markdown
+        run: |
+          php phpunit/extract.php \
+            ${{ github.workspace }}/phpunit/integration/GovCMS
+
+      - name: Commit and push changes
+        run: |
+          mkdir -p ${{ github.workspace }}/phpunit/docs
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@github.com'
+          git add ${{ github.workspace }}/phpunit/docs/
+          if ! git diff-index --quiet HEAD; then
+          git commit -m "Update generated docs"
+          git push
+          fi

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -36,6 +36,6 @@ jobs:
           git config --global user.email 'github-actions[bot]@github.com'
           git add ${{ github.workspace }}/phpunit/docs/
           if ! git diff-index --quiet HEAD; then
-          git commit -m "Update generated docs"
+          git commit -m "[skip ci] Update generated docs"
           git push
           fi

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -4,8 +4,10 @@ name: Generate test documentation
 on:  # yamllint disable-line rule:truthy
   push:
     branches: ["3.x-develop"]
+    paths: ['phpunit/**']
   pull_request:
     branches: ["3.x-develop"]
+    paths: ['phpunit/**']
 
 jobs:
   generate-docs:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,10 +1,11 @@
+---
 name: Builder - Node.js
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
   pull_request:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
 
 jobs:
   build:
@@ -13,7 +14,8 @@ jobs:
     strategy:
       matrix:
         node-version: [20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        # See supported Node.js release schedule
+        # at https://nodejs.org/en/about/releases/
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,10 +1,11 @@
+---
 name: Builder - PHP Composer
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
   pull_request:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
 
 permissions:
   contents: read

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,10 +1,11 @@
+---
 name: GovCMS CI Tests - PHPUnit
 
-on:
+on:  # yamllint disable-line rule:truthy
   push:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
   pull_request:
-    branches: [ "3.x-develop" ]
+    branches: ["3.x-develop"]
 
 permissions:
   contents: read
@@ -25,33 +26,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run PHPUnit tests
         run: |
-           docker exec ${{ job.services.web.id }} govcms-phpunit --testdox --testsuite govcms-integration
-  generate-docs:
-    permissions:
-      contents: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          ssh-key: ${{secrets.BYPASS_BRANCH_PROTECTION}}
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.1' # specify the PHP version you need
-
-      - name: Run PHP script to generate Markdown
-        run: php phpunit/extract.php /home/runner/work/tests/tests/phpunit/integration/GovCMS
-
-      - name: Commit and push changes
-        run: |
-          mkdir -p ${{ github.workspace }}/phpunit/docs
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add ${{ github.workspace }}/phpunit/docs/
-          if ! git diff-index --quiet HEAD; then
-          git commit -m "Update generated docs"
-          git push
-          fi
-        #env:
-          #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          docker exec ${{ job.services.web.id }} \
+            govcms-phpunit --testdox --testsuite govcms-integration


### PR DESCRIPTION
I've made several improvements:

- They are linted by yamllint
- The generate_docs workflow runs only on changes to the phpunit folder
- The commits made by github-actions[bot] skip the ci, so that the ci tests are not run twice for every commit
- generate_docs is now in a separate file