### PR TITLE
[GOVCMS-11933] Add behat mink goutte driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL-2.0-or-later",
     "require": {
         "behat/behat": "^3",
+        "behat/mink-goutte-driver": "*",
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "drevops/behat-format-progress-fail": "^1.0",
         "drevops/behat-screenshot": "^1.2",
@@ -15,7 +16,9 @@
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phploc/phploc": "^7.0",
-        "phpmd/phpmd": "^2.10"
+        "phpmd/phpmd": "^2.10",
+        "symfony/dependency-injection": "^6",
+        "symfony/event-dispatcher": "^6"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
Part of a series of PRs to fix [GOVCMS-11933](https://osbfinance.atlassian.net/browse/GOVCMS-11933).

Installs Behat Mink Goutte Driver (a dependency of the Drupal Extension of Behat), and ensure certain symfony components are locked to version 6.