### PR TITLE
[GOVCMSD10-1303] Added PHPUnit dependency to composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phploc/phploc": "^7.0",
         "phpmd/phpmd": "^2.10",
+        "phpunit/phpunit": "^9.6.13",
         "symfony/dependency-injection": "^6",
         "symfony/event-dispatcher": "^6"
     },


### PR DESCRIPTION
The `govcms/tests` image doesn't include a PHPUnit dependency hence it doesn't have the `phpunit` executable and `ahoy test-phpunit` is not working for GovCMS. Its CI image however has `phpunit` executable hence GHA and CircleCI can run unit tests.

The CI image is based on the govcms/govcms image which does not have PHPUnit with --no-dev [option](https://github.com/govCMS/lagoon/blob/3.x-develop/.docker/Dockerfile.govcms#L32C1-L33C1):
```
RUN --mount=type=cache,target=/root/.composer/cache \
    composer update --with-all-dependencies
```
`composer update --with-all-dependencies` basically updates all packages and all dependencies including dev packages, in this case `phpunit/phpunit` is a dependency of `drupal/core-dev` which is [a dev dependency](https://github.com/govCMS/GovCMS/blob/3.x-develop/composer.json#L122) of `govcms/govcms`.

`govcms-tests/tests` should explicitly include `phpunit/phpunit` so that PHPUnit is available for all sites in the test image.