### PR TITLE
Update test syntax for Drush 13

### DIFF
--- a/cy/cypress/e2e/3-modules/search.cy.js
+++ b/cy/cypress/e2e/3-modules/search.cy.js
@@ -41,7 +41,7 @@ describe('Search functionality works as expected', () => {
 
     it('Clean up', () => {
         cy.uninstall('search')
-        cy.execDrush('entity:delete node')
+        cy.execDrush('entity:delete node -y')
     })
 
 })

--- a/cy/cypress/e2e/3-modules/webforms.cy.js
+++ b/cy/cypress/e2e/3-modules/webforms.cy.js
@@ -79,9 +79,9 @@ describe('User can create webforms with file attachment fields', () => {
 
 
     it('Clean up', () => {
-        cy.execDrush('entity:delete file')
-        cy.execDrush('entity:delete webform')
-        cy.execDrush('entity:delete node')
+        cy.execDrush('entity:delete file -y')
+        cy.execDrush('entity:delete webform -y')
+        cy.execDrush('entity:delete node -y')
         cy.execDrush('-y pm:uninstall webform_node')
         cy.execDrush('-y pm:uninstall webform')
         cy.execDrush('-y cset honeypot.settings time_limit 5')

--- a/cy/cypress/e2e/3-modules/webforms.cy.js
+++ b/cy/cypress/e2e/3-modules/webforms.cy.js
@@ -5,7 +5,7 @@ const formTitle = randString(10)
 describe('User can create webforms with file attachment fields', () => {
     it('Set up the webform module', () => {
         // Ensure no existing files
-        cy.execDrush('entity:delete file')
+        cy.execDrush('entity:delete file -y')
         // Install
         cy.execDrush('-y pm:install webform, webform_node')
     })


### PR DESCRIPTION
A change in how the `entity:delete` drush command works (?) now requires passing a confirm flag.