### PR TITLE
Update tests to dynamic JSON:API version

### DIFF
--- a/phpunit/integration/GovCMS/Security/Functional/JsonApiFileUploadTest.php
+++ b/phpunit/integration/GovCMS/Security/Functional/JsonApiFileUploadTest.php
@@ -15,6 +15,7 @@ use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\file\Entity\File;
 use Drupal\govcms_security\GovcmsFileConstraintInterface;
+use Drupal\jsonapi\JsonApiSpec;
 use Drupal\user\RoleInterface;
 use Drupal\user\UserInterface;
 use Drupal\user\Entity\Role;
@@ -281,10 +282,10 @@ class JsonApiFileUploadTest extends BrowserTestBase {
       'jsonapi' => [
         'meta' => [
           'links' => [
-            'self' => ['href' => 'http://jsonapi.org/format/1.0/'],
+            'self' => ['href' => JsonApiSpec::SUPPORTED_SPECIFICATION_PERMALINK],
           ],
         ],
-        'version' => '1.0',
+        'version' => JsonApiSpec::SUPPORTED_SPECIFICATION_VERSION,
       ],
       'links' => [
         'self' => ['href' => $self_url],


### PR DESCRIPTION
Drupal 11.2 updates to 1.1 version of JSON:API spec causing test failures on string comparison.
This change loads the test data with the version used by core at run time.