### PR TITLE
Turn off security blocking for Composer 2.9

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -12,6 +12,7 @@ WORKDIR /app/
 
 # Set environment variables
 ENV PATH="${PATH}:/app/tests/vendor/bin:/app/vendor/bin:/app/bin" \
+    COMPOSER_NO_SECURITY_BLOCKING=1 \
     SIMPLETEST_BASE_URL="http://localhost" \
     SIMPLETEST_DB="sqlite://sites/default/files/.ht.sqlite"
 


### PR DESCRIPTION
Composer 2.9 added a new feature to not install versions of packages that security advisories. Within our test suite we need this functionality turned off so that our images can still be built.